### PR TITLE
clarification for triple-slash-reference-types

### DIFF
--- a/pages/Triple-Slash Directives.md
+++ b/pages/Triple-Slash Directives.md
@@ -40,18 +40,18 @@ If the compiler flag `--noResolve` is specified, triple-slash references are ign
 ## `/// <reference types="..." />`
 
 Similar to a `/// <reference path="..." />` directive,  this directive serves as a declaration of *dependency*;
-a `/// <reference types="..." />`, however, declares a dependency on an `@types` package.
+a `/// <reference types="..." />` directive, however, declares a dependency on a package.
 
-Including `/// <reference types="node" />` in a declaration file declares that this file uses names declared in `@types/node/index.d.ts`;
+The process of resolving these package names is similar to the process of resolving module names in an `import` statement.
+An easy way to think of triple-slash-reference-types directives are as an `import` for declaration packages.
+
+For example, including `/// <reference types="node" />` in a declaration file declares that this file uses names declared in `@types/node/index.d.ts`;
 and thus, this package needs to be included in the compilation along with the declaration file.
-
-The process of resolving these `@types` package names are similar to process of resolving module names in an `import` statement.
-An easy way to think of triple-slash-reference-types directives as an `import` for declaration packages.
 
 Use these directives only when you're authoring a `d.ts` file by hand.
 
 For declaration files generated during compilation, the compiler will automatically add `/// <reference types="..." />` for you;
-A `/// <reference types="..." />` in a generated declaration file is added *if and only if* the resulting file uses any declarations from the referenced `@types` package.
+A `/// <reference types="..." />` in a generated declaration file is added *if and only if* the resulting file uses any declarations from the referenced package.
 
 For declaring a dependency on an `@types` package in a `.ts` file, use `--types` on the command line or in your `tsconfig.json` instead.
 See [using `@types`, `typeRoots` and `types` in `tsconfig.json` files](./tsconfig.json.md#types-typeroots-and-types) for more details.


### PR DESCRIPTION
Currently the documentation states that triple slash reference types will only resolve with `@types` packages, but this is not correct.

<!--
Thank you for submitting a pull request!

If your update corresponds to a future version of the language, your pull request should target the appropriate branch.
For instance, if any new content corresponds to changes in TypeScript X.Y, you should target the release-X.Y branch.

Here's a few things we usually expect beforehand.

* There is an associated issue which is not currently assigned, or which you've asked to work on.
* Code is up-to-date with the respective branch.
* You've stayed consistent with style guidelines (one sentence per line, passing linter rules).

Refer to CONTRIBUTING.MD for more details.
    https://github.com/Microsoft/TypeScript-Handbook/blob/master/CONTRIBUTING.md
-->

Fixes #
